### PR TITLE
fix(journal): resolve data loss race condition and add explicit check save button

### DIFF
--- a/frontend/src/components/JournalOverlay.jsx
+++ b/frontend/src/components/JournalOverlay.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useState } from 'react';
 import { motion } from 'framer-motion';
-import { X, Bold, Italic, Underline as UnderlineIcon, List, ListOrdered, CheckSquare, AlignLeft, AlignCenter, AlignRight } from 'lucide-react';
+import { X, Check, Bold, Italic, Underline as UnderlineIcon, List, ListOrdered, CheckSquare, AlignLeft, AlignCenter, AlignRight } from 'lucide-react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import { Extension } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
@@ -118,8 +118,13 @@ function ColorSwatch({ color, active, onClick }) {
 }
 
 export default function JournalOverlay({ contextKey, displayTitle, onClose }) {
-    const { content, setContent, saveStatus } = useLocalJournal(contextKey);
+    const { content, setContent, saveStatus, forceSave } = useLocalJournal(contextKey);
     const [, forceUpdate] = useState(0); // Used to ensure toolbar active states update instantly
+
+    const handleClose = useCallback(() => {
+        forceSave();
+        onClose();
+    }, [forceSave, onClose]);
 
     const editor = useEditor({
         extensions: [
@@ -164,11 +169,11 @@ export default function JournalOverlay({ contextKey, displayTitle, onClose }) {
     // Close on Escape
     useEffect(() => {
         const handler = (e) => {
-            if (e.key === 'Escape') onClose();
+            if (e.key === 'Escape') handleClose();
         };
         window.addEventListener('keydown', handler);
         return () => window.removeEventListener('keydown', handler);
-    }, [onClose]);
+    }, [handleClose]);
 
     // Focus editor on open
     useEffect(() => {
@@ -196,7 +201,7 @@ export default function JournalOverlay({ contextKey, displayTitle, onClose }) {
     return (
         <motion.div
             className="fixed inset-0 z-50 flex items-center justify-center journal-backdrop"
-            onClick={onClose}
+            onClick={handleClose}
             {...BACKDROP}
         >
             <motion.div
@@ -226,24 +231,45 @@ export default function JournalOverlay({ contextKey, displayTitle, onClose }) {
                             {statusLabel || '\u00A0'}
                         </p>
                     </div>
-                    <button
-                        onClick={onClose}
-                        className="p-2 rounded-full transition-colors duration-200"
-                        style={{
-                            backgroundColor: 'var(--control-bg)',
-                            color: 'var(--fg-muted)',
-                            flexShrink: 0,
-                        }}
-                        onMouseEnter={(e) =>
-                            (e.target.style.backgroundColor = 'var(--control-hover)')
-                        }
-                        onMouseLeave={(e) =>
-                            (e.target.style.backgroundColor = 'var(--control-bg)')
-                        }
-                        aria-label="Close journal"
-                    >
-                        <X size={16} />
-                    </button>
+                    <div className="flex items-center gap-2">
+                        <button
+                            onClick={handleClose}
+                            className="p-2 rounded-full transition-colors duration-200"
+                            style={{
+                                backgroundColor: 'var(--control-bg)',
+                                color: 'var(--fg)', // slightly darker than fg-muted to emphasize done
+                                flexShrink: 0,
+                            }}
+                            onMouseEnter={(e) =>
+                                (e.target.style.backgroundColor = 'rgba(74, 222, 128, 0.1)') // Subtly green hover
+                            }
+                            onMouseLeave={(e) =>
+                                (e.target.style.backgroundColor = 'var(--control-bg)')
+                            }
+                            aria-label="Save and close journal"
+                            title="Save & Close"
+                        >
+                            <Check size={16} style={{ color: 'var(--color-green, #4ade80)' }} />
+                        </button>
+                        <button
+                            onClick={handleClose}
+                            className="p-2 rounded-full transition-colors duration-200"
+                            style={{
+                                backgroundColor: 'var(--control-bg)',
+                                color: 'var(--fg-muted)',
+                                flexShrink: 0,
+                            }}
+                            onMouseEnter={(e) =>
+                                (e.target.style.backgroundColor = 'var(--control-hover)')
+                            }
+                            onMouseLeave={(e) =>
+                                (e.target.style.backgroundColor = 'var(--control-bg)')
+                            }
+                            aria-label="Close journal"
+                        >
+                            <X size={16} />
+                        </button>
+                    </div>
                 </div>
 
                 {/* Toolbar */}

--- a/frontend/src/hooks/useLocalJournal.js
+++ b/frontend/src/hooks/useLocalJournal.js
@@ -18,15 +18,21 @@ function readAll() {
  *   saveStatus: 'idle' | 'saving' | 'saved'
  */
 export default function useLocalJournal(contextKey) {
-    const [content, setContentState] = useState('');
+    const [content, setContentState] = useState(() => {
+        const all = readAll();
+        return all[contextKey] || '';
+    });
     const [saveStatus, setSaveStatus] = useState('idle'); // idle | saving | saved
     const timerRef = useRef(null);
     const savedTimerRef = useRef(null);
+    const latestContentRef = useRef(content); // Synchronous tracking for unmounts
 
-    // Load entry whenever contextKey changes
+    // Sync state if contextKey changes while hook is still mounted
     useEffect(() => {
         const all = readAll();
-        setContentState(all[contextKey] || '');
+        const initialContent = all[contextKey] || '';
+        setContentState(initialContent);
+        latestContentRef.current = initialContent;
         setSaveStatus('idle');
 
         // Clear pending timers on key change
@@ -36,32 +42,50 @@ export default function useLocalJournal(contextKey) {
         };
     }, [contextKey]);
 
+    const forceSave = useCallback(() => {
+        clearTimeout(timerRef.current);
+        clearTimeout(savedTimerRef.current);
+
+        const value = latestContentRef.current;
+        const all = readAll();
+        const isEmpty = !value || value === '<p></p>' || value.trim() === '';
+
+        if (!isEmpty) {
+            all[contextKey] = value;
+        } else {
+            delete all[contextKey]; // clean up empty entries
+        }
+
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+        setSaveStatus('saved');
+
+        savedTimerRef.current = setTimeout(() => setSaveStatus('idle'), 2000);
+    }, [contextKey]);
+
     const setContent = useCallback(
         (value) => {
             setContentState(value);
+            latestContentRef.current = value; // Update ref synchronously
             setSaveStatus('saving');
 
             // Debounce the write
             clearTimeout(timerRef.current);
             timerRef.current = setTimeout(() => {
-                const all = readAll();
-                // Treat empty paragraphs as empty
-                const isEmpty = !value || value === '<p></p>' || value.trim() === '';
-                if (!isEmpty) {
-                    all[contextKey] = value;
-                } else {
-                    delete all[contextKey]; // clean up empty entries
-                }
-                localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
-                setSaveStatus('saved');
-
-                // Reset to idle after a brief flash
-                clearTimeout(savedTimerRef.current);
-                savedTimerRef.current = setTimeout(() => setSaveStatus('idle'), 2000);
+                forceSave();
             }, 500);
         },
-        [contextKey],
+        [forceSave], // forceSave depends on contextKey
     );
 
-    return { content, setContent, saveStatus };
+    // Auto-save when the component entirely unmounts (e.g., overlay is closed)
+    useEffect(() => {
+        return () => {
+            if (timerRef.current) {
+                // If there was a pending save, execute it immediately on unmount
+                forceSave();
+            }
+        };
+    }, [forceSave]);
+
+    return { content, setContent, saveStatus, forceSave };
 }


### PR DESCRIPTION
## Overview
This PR addresses a critical bug where journal entries were occasionally being lost when closing the journal overlay quickly. It also introduces a new manual save button to give users explicit control and peace of mind over saving their entries.

### 🐛 Bug Fixes
* **Race Condition in Journal Initialization**: 
  * **The Problem:** The rich text editor was initializing a fraction of a second *before* the saved content could complete its asynchronous fetch from `localStorage`. If the user closed the journal during this tiny window, the empty initialized state would trigger an autosave, wiping out the previously saved journal entry.
  * **The Solution:** Modified the state initialization in the `useLocalJournal` hook to be fully **synchronous** (`useState(() => readAll()[contextKey])`). The editor now initializes perfectly with the actual saved data on the very first render, eliminating the race condition.
* **Forced Save on Unmount**:
  * Implemented a `forceSave()` function that bypasses the 500ms debounce timer.
  * The journal overlay now intercepts all close actions (clicking the X, pressing Escape, or clicking the background backdrop) and executes a synchronous `forceSave()` *before* unmounting the component, ensuring no data is ever lost in transit.

### ✨ New Features
* **Explicit Save & Close Button (Tick Mark)**: Added a new Checkmark button next to the Close (X) button in the journal header. Clicking this gives users a satisfying, manual way to explicitly force a save and gracefully close the panel.