### PR TITLE
fix(frontend): mobile scroll fix, clean empty journals, and clickable links

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@tiptap/extension-color": "^3.20.1",
         "@tiptap/extension-font-family": "^3.20.1",
         "@tiptap/extension-heading": "^3.20.1",
+        "@tiptap/extension-link": "^3.20.1",
         "@tiptap/extension-list-keymap": "^3.20.1",
         "@tiptap/extension-task-item": "^3.20.1",
         "@tiptap/extension-task-list": "^3.20.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@tiptap/extension-color": "^3.20.1",
     "@tiptap/extension-font-family": "^3.20.1",
     "@tiptap/extension-heading": "^3.20.1",
+    "@tiptap/extension-link": "^3.20.1",
     "@tiptap/extension-list-keymap": "^3.20.1",
     "@tiptap/extension-task-item": "^3.20.1",
     "@tiptap/extension-task-list": "^3.20.1",

--- a/frontend/src/components/DotGrid.jsx
+++ b/frontend/src/components/DotGrid.jsx
@@ -128,7 +128,7 @@ function Dot({ status, label, onClick, onContextMenu, index, size = 'sm', heartb
                 style={{
                     backgroundColor,
                     border,
-                    touchAction: 'none',
+                    touchAction: 'pan-y', // Allows vertical scrolling on phones
                     WebkitTouchCallout: 'none',
                     WebkitUserSelect: 'none',
                     userSelect: 'none'

--- a/frontend/src/components/JournalOverlay.jsx
+++ b/frontend/src/components/JournalOverlay.jsx
@@ -11,6 +11,7 @@ import FontFamily from '@tiptap/extension-font-family';
 import TaskItem from '@tiptap/extension-task-item';
 import TaskList from '@tiptap/extension-task-list';
 import TextAlign from '@tiptap/extension-text-align';
+import Link from '@tiptap/extension-link';
 import useLocalJournal from '../hooks/useLocalJournal';
 
 const BackspaceListFix = Extension.create({
@@ -138,6 +139,13 @@ export default function JournalOverlay({ contextKey, displayTitle, onClose }) {
             TaskItem.configure({ nested: true }),
             BackspaceListFix,
             TextAlign.configure({ types: ['heading', 'paragraph'] }),
+            Link.configure({
+                openOnClick: false,
+                HTMLAttributes: {
+                    class: 'journal-link',
+                },
+                autolink: true,
+            }),
         ],
         content: content || '',
         onUpdate: ({ editor: ed }) => {

--- a/frontend/src/hooks/useLocalJournal.js
+++ b/frontend/src/hooks/useLocalJournal.js
@@ -48,7 +48,7 @@ export default function useLocalJournal(contextKey) {
 
         const value = latestContentRef.current;
         const all = readAll();
-        const isEmpty = !value || value === '<p></p>' || value.trim() === '';
+        const isEmpty = !value || value === '<p></p>' || value === '<p><br></p>' || value.trim() === '';
 
         if (!isEmpty) {
             all[contextKey] = value;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -448,6 +448,12 @@ body {
   line-height: 1.3;
 }
 
+.journal-link {
+  color: #3b82f6;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 /* Placeholder */
 .journal-editor-content p.is-editor-empty:first-child::before {
   content: 'Start writing…';


### PR DESCRIPTION
## Overview
This PR addresses three specific frontend polish requests, ensuring a smoother mobile experience and cleaner data handling.

### 📱 Mobile UX Improvements
* **Mobile Scroll Block Fix**: 
  * The `touchAction` on the grid's `<Dot>` components has been updated from `none` to `pan-y`. This correctly permits standard vertical page scrolling on extremely dense touch displays, while continuing to restrict horizontal swiping or zooming that might interfere with the custom long-press context menus.

### 📝 Journal & Rich Text Polish
* **TipTap Empty Content Detection**: 
  * TipTap gracefully inserts a `<br>` tag when a paragraph naturally empties out (leaving `<p><br></p>`). The `useLocalJournal` `isEmpty` constraint has been updated to explicitly catch this string configuration. Now, erasing a journal entry fully registers as empty rather than persisting invisible garbage data in `localStorage`.
* **Clickable Hyperlinks**: 
  * Integrated the `@tiptap/extension-link` with `autolink` enabled so pasting URLs instantly creates proper anchor tags.
  * `openOnClick` is set to false to ensure users can safely click 'into' the link text to edit it without aggressively redirecting their browser mid-thought.
  * Introduced the `.journal-link` CSS class to render links as subtle, standard underlined blue text.