### PR TITLE
fix(F03): remove Jump to Today button from main header

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,7 +16,7 @@ import { getLifeStats, getCalendarDate, getBirthDate, hydrateFromRemote, formatC
 import { getAllDotMeta, setDotMeta, hydrateMetaFromRemote } from './utils/dotMeta';
 import AllJournalsModal from './components/AllJournalsModal';
 import AllTodosModal from './components/AllTodosModal';
-import { ListTodo, BookOpen, CalendarHeart } from 'lucide-react';
+import { ListTodo, BookOpen } from 'lucide-react';
 
 const viewVariants = {
   initial: (navDir) => {
@@ -611,22 +611,6 @@ export default function App() {
         />
         <JournalButton onClick={() => setJournalOpen(true)} />
         <TodoButton onClick={() => setTodoOpen(true)} />
-        <div
-          className="w-px h-5"
-          style={{ backgroundColor: 'var(--control-border)' }}
-        />
-        <button
-          onClick={jumpToToday}
-          className="p-[6px] rounded flex items-center justify-center transition-all duration-200 hover:scale-105 active:scale-95"
-          style={{
-            color: 'var(--fg)',
-            backgroundColor: 'var(--control-bg)',
-            border: '1px solid var(--control-border)',
-          }}
-          title="Jump to Today"
-        >
-          <CalendarHeart size={16} />
-        </button>
       </div>
 
       {/* Grid Area */}


### PR DESCRIPTION
Closes #20

## What changed
- Removed the `CalendarHeart` button from the controls bar — it was visual noise on a minimalistic interface
- Removed `CalendarHeart` from the `lucide-react` import (now unused)
- Kept `jumpToToday()` function intact — it can be wired to a keyboard shortcut (e.g. `T`) in a follow-up if desired

## Files changed
- `frontend/src/App.jsx`

## Test plan
- [ ] Controls bar no longer shows the calendar-heart icon
- [ ] No console errors (unused import removed cleanly)
- [ ] All other controls (View, Theme, Export, Journal, Todo) still work normally